### PR TITLE
Add MIT license and reference in README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ColorBook Engine Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,10 @@ npm run dev
 
 **Your professional coloring book creation tool is complete and ready for business!** 🎨✨
 
+## License
+
+This project is licensed under the [MIT License](LICENSE).
+
 ---
 
-*From messy prototype to production-ready application - transformation complete!*"# colorbook-engine-clean" 
+*From messy prototype to production-ready application - transformation complete!*"# colorbook-engine-clean"


### PR DESCRIPTION
## Summary
- add MIT LICENSE file in repo root
- update README with license information

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix backend install` *(fails: No matching version found)*
- `npm --prefix backend test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840e3836c98832f90c09bcbd587a8f4

## Summary by Sourcery

Add MIT license and reference it in README

Enhancements:
- Add MIT LICENSE file at the repository root

Documentation:
- Add a License section in README linking to the MIT License file