### PR TITLE
Require JWT secret for auth

### DIFF
--- a/backend/src/middleware/auth.js
+++ b/backend/src/middleware/auth.js
@@ -1,7 +1,10 @@
 const jwt = require('jsonwebtoken');
 const { query } = require('../database/connection');
 
-const JWT_SECRET = process.env.JWT_SECRET || 'your-super-secret-jwt-key-change-this-in-production';
+const JWT_SECRET = process.env.JWT_SECRET;
+if (!JWT_SECRET) {
+  throw new Error('JWT_SECRET environment variable is required');
+}
 const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '7d';
 
 // Generate JWT token


### PR DESCRIPTION
## Summary
- enforce presence of `JWT_SECRET` by throwing an error

## Testing
- `npm install` *(fails: No matching version found for rate-limiter-flexible)*

------
https://chatgpt.com/codex/tasks/task_e_6840e381ef5c832f988d5a81c07b5405