### PR TITLE
Fix rate-limiter version

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -24,7 +24,7 @@
     "sharp": "^0.32.6",
     "uuid": "^9.0.1",
     "joi": "^17.11.0",
-    "rate-limiter-flexible": "^3.0.8",
+    "rate-limiter-flexible": "^3.0.6",
     "compression": "^1.7.4",
     "morgan": "^1.10.0",
     "stripe": "^13.11.0",


### PR DESCRIPTION
## Summary
- pin backend's `rate-limiter-flexible` dependency to an available 3.x release

## Testing
- `npm install --silent` in `backend` with Node 20

------
https://chatgpt.com/codex/tasks/task_e_6840e6ec4284832f8c390b1f8ce93c7b

## Summary by Sourcery

Bug Fixes:
- Downgrade rate-limiter-flexible from ^3.0.8 to ^3.0.6 to use an available release