### PR TITLE
Fix high vulnerability by updating jspdf

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "fabric": "^5.3.0",
         "framer-motion": "^10.12.0",
         "html2canvas": "^1.4.1",
-        "jspdf": "^2.5.2",
+        "jspdf": "^3.0.1",
         "jszip": "^3.10.1",
         "lucide-react": "^0.263.1",
         "react": "^18.2.0",
@@ -1272,6 +1272,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.21.0.tgz",
@@ -2336,11 +2343,14 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-2.5.8.tgz",
-      "integrity": "sha512-o1vSNgrmYMQObbSSvF/1brBYEQPHhV1+gsmrusO7/GXtp1T9rCS8cXFqVxK/9crT1jA6Ccv+5MTSjBNqr7Sovw==",
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.2.6.tgz",
+      "integrity": "sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "optional": true
+      "optional": true,
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3650,20 +3660,20 @@
       }
     },
     "node_modules/jspdf": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-2.5.2.tgz",
-      "integrity": "sha512-myeX9c+p7znDWPk0eTrujCzNjT+CXdXyk7YmJq5nD5V7uLLKmSXnlQ/Jn/kuo3X09Op70Apm0rQSnFWyGK8uEQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/jspdf/-/jspdf-3.0.1.tgz",
+      "integrity": "sha512-qaGIxqxetdoNnFQQXxTKUD9/Z7AloLaw94fFsOiJMxbfYdBbrBuhWmbzI8TVjrw7s3jBY1PFHofBKMV/wZPapg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
+        "@babel/runtime": "^7.26.7",
         "atob": "^2.1.2",
         "btoa": "^1.2.1",
         "fflate": "^0.8.1"
       },
       "optionalDependencies": {
-        "canvg": "^3.0.6",
+        "canvg": "^3.0.11",
         "core-js": "^3.6.0",
-        "dompurify": "^2.5.4",
+        "dompurify": "^3.2.4",
         "html2canvas": "^1.0.0-rc.5"
       }
     },

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "fabric": "^5.3.0",
     "framer-motion": "^10.12.0",
     "html2canvas": "^1.4.1",
-    "jspdf": "^2.5.2",
+    "jspdf": "^3.0.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.263.1",
     "react": "^18.2.0",
@@ -29,6 +29,7 @@
   "devDependencies": {
     "@types/jspdf": "^1.3.3",
     "@types/jszip": "^3.4.0",
+    "@types/node": "^20.2.5",
     "@types/react": "^18.2.15",
     "@types/react-dom": "^18.2.7",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
@@ -40,7 +41,6 @@
     "eslint-plugin-react-refresh": "^0.4.3",
     "postcss": "^8.4.24",
     "tailwindcss": "^3.3.0",
-    "@types/node": "^20.2.5",
     "typescript": "^5.0.2",
     "vite": "^4.4.5"
   }


### PR DESCRIPTION
## Summary
- update `jspdf` dependency to 3.0.1 to patch DOMPurify vulnerability

## Testing
- `npm audit --omit=dev`
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6840e6f2a4e0832f86e8bdac2cd4d2b2

## Summary by Sourcery

Upgrade jspdf to version 3.0.1 and add Node type definitions to patch a DOMPurify security vulnerability

Bug Fixes:
- Upgrade jspdf dependency to v3.0.1 to patch the DOMPurify vulnerability

Enhancements:
- Add @types/node to devDependencies for improved type support