### PR TITLE
Implement basic performance metrics logging

### DIFF
--- a/backend/src/middleware/performanceLogger.js
+++ b/backend/src/middleware/performanceLogger.js
@@ -1,0 +1,29 @@
+const performanceTracker = require('../services/performanceTracker');
+
+// Middleware to log response time, CPU, and memory usage for key endpoints
+module.exports = (req, res, next) => {
+  const startHrTime = process.hrtime();
+  const startCpu = process.cpuUsage();
+
+  res.on('finish', () => {
+    const hrDiff = process.hrtime(startHrTime);
+    const durationMs = hrDiff[0] * 1000 + hrDiff[1] / 1e6;
+    const cpuDiff = process.cpuUsage(startCpu);
+    const mem = process.memoryUsage();
+
+    if (['/api/generateStory', '/api/exportPdf'].includes(req.path)) {
+      const data = {
+        method: req.method,
+        statusCode: res.statusCode,
+        responseTimeMs: Math.round(durationMs),
+        cpu: { user: cpuDiff.user, system: cpuDiff.system },
+        memory: { rss: mem.rss, heapUsed: mem.heapUsed, heapTotal: mem.heapTotal },
+        timestamp: Date.now()
+      };
+      performanceTracker.record(req.path, data);
+      console.log('PERFORMANCE', req.path, data);
+    }
+  });
+
+  next();
+};

--- a/backend/src/routes/monitoring.js
+++ b/backend/src/routes/monitoring.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const os = require('os');
 const { Pool } = require('pg');
+const performanceTracker = require('../services/performanceTracker');
 const router = express.Router();
 
 // Database connection for health checks
@@ -233,6 +234,22 @@ router.get('/errors', async (req, res) => {
     console.error('Error summary failed:', error);
     res.status(500).json({
       error: 'Failed to get error summary',
+      message: error.message
+    });
+  }
+});
+
+// Performance metrics for specific endpoints
+router.get('/performance', (req, res) => {
+  try {
+    res.json({
+      timestamp: new Date().toISOString(),
+      metrics: performanceTracker.getMetrics()
+    });
+  } catch (error) {
+    console.error('Performance metrics failed:', error);
+    res.status(500).json({
+      error: 'Failed to get performance metrics',
       message: error.message
     });
   }

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -5,6 +5,7 @@ const helmet = require('helmet');
 const compression = require('compression');
 const morgan = require('morgan');
 const rateLimit = require('rate-limiter-flexible');
+const performanceLogger = require('./middleware/performanceLogger');
 
 // Import routes
 const authRoutes = require('./routes/auth');
@@ -64,6 +65,7 @@ app.use(compression());
 app.use(morgan('combined'));
 app.use(express.json({ limit: '10mb' }));
 app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+app.use(performanceLogger);
 
 // Apply rate limiting
 app.use(rateLimitMiddleware);

--- a/backend/src/services/performanceTracker.js
+++ b/backend/src/services/performanceTracker.js
@@ -1,0 +1,21 @@
+class PerformanceTracker {
+  constructor() {
+    this.metrics = {};
+  }
+
+  record(endpoint, data) {
+    if (!this.metrics[endpoint]) {
+      this.metrics[endpoint] = [];
+    }
+    this.metrics[endpoint].push(data);
+    if (this.metrics[endpoint].length > 100) {
+      this.metrics[endpoint].shift();
+    }
+  }
+
+  getMetrics() {
+    return this.metrics;
+  }
+}
+
+module.exports = new PerformanceTracker();


### PR DESCRIPTION
## Summary
- add performance tracking service and middleware
- expose endpoint metrics via `/api/monitoring/performance`
- register performance logger middleware in server

## Testing
- `npm test` *(fails: jest not found)*
- `npm install` *(fails: No matching version found for rate-limiter-flexible@^3.0.8)*

------
https://chatgpt.com/codex/tasks/task_e_6840e7285b6c832f98607c7c4d025700

## Summary by Sourcery

Implement basic performance metrics logging by registering middleware to capture and record performance data for specific API routes, persisting them in a tracker service, and providing an endpoint to fetch the metrics.

New Features:
- Add middleware to log response time, CPU, and memory usage for key endpoints
- Introduce a performanceTracker service to record and retrieve per-endpoint metrics
- Expose collected performance metrics via a new GET /api/monitoring/performance endpoint

Enhancements:
- Limit stored metrics per endpoint to the most recent 100 entries