### PR TITLE
Convert open tasks file to stub format

### DIFF
--- a/OPEN_TASKS.md
+++ b/OPEN_TASKS.md
@@ -1,0 +1,37 @@
+# Outstanding Tasks for Full Functionality
+
+The following tasks outline the remaining work needed to make the ColorBook Engine ready for production.
+
+:::task-stub{title="Backend Synchronization"}
+Replace the placeholder logic in `src/utils/persistentStorage.ts` (`syncToBackend`) with real API calls to persist user data.
+:::
+
+:::task-stub{title="Monitoring and Analytics"}
+Implement real analytics and error tracking in `backend/src/routes/monitoring.js` instead of returning placeholder data.
+:::
+
+:::task-stub{title="Production Environment Configuration"}
+Configure Stripe API keys, database connections, and required environment variables as noted in `PRODUCTION_READINESS.md`.
+:::
+
+:::task-stub{title="Domain and SSL Setup"}
+Configure a production domain and obtain valid SSL certificates.
+:::
+
+:::task-stub{title="Comprehensive Testing"}
+Expand the current test suite to cover all API endpoints and user workflows.
+:::
+
+:::task-stub{title="Image Generator Work-In-Progress"}
+Finalize the image generator module; currently acknowledged as a work in progress.
+:::
+
+:::task-stub{title="Backend Integration Testing"}
+Verify functionality with the backend server running to ensure proper data persistence and API calls.
+:::
+
+:::task-stub{title="AI Workflow Keys Required"}
+Provide valid API keys for image and story generation so end-to-end tests can be executed.
+:::
+
+These tasks will bring the app closer to a true production-ready state.


### PR DESCRIPTION
## Summary
- rewrite OPEN_TASKS.md using `task-stub` markup

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6840ecfccecc832fa4739a93ca910aa3

## Summary by Sourcery

Documentation:
- Restructure OPEN_TASKS.md using task-stub blocks to outline each remaining task.