### PR TITLE
Update section names for new navigation

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -55,7 +55,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onOpenStorage }) => {
       description: 'Create engaging stories with detailed image prompts for coloring pages',
       icon: BookOpen,
       color: 'from-blue-500 to-purple-600',
-      action: () => setCurrentSection('story')
+      action: () => setCurrentSection('story-generator')
     },
     {
       title: 'Digital Canvas',
@@ -90,7 +90,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onOpenStorage }) => {
       description: 'Configure OpenRouter API for story and image generation',
       icon: Settings,
       color: 'from-gray-500 to-gray-700',
-      action: () => setCurrentSection('settings')
+      action: () => setCurrentSection('api-settings')
     }
   ];
 
@@ -309,7 +309,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onOpenStorage }) => {
                 Create New Project
               </button>
               <button
-                onClick={() => setCurrentSection('story')}
+                onClick={() => setCurrentSection('story-generator')}
                 className="bg-green-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-green-700 transition-colors duration-200"
               >
                 Generate AI Story

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -60,7 +60,7 @@ const Projects: React.FC = () => {
 
   const handleOpenProject = (project: Project) => {
     setCurrentProject(project);
-    setCurrentSection('story');
+    setCurrentSection('story-generator');
     addNotification({
       type: 'success',
       message: `Opened project: ${project.title}`

--- a/src/components/StoryGenerator.tsx
+++ b/src/components/StoryGenerator.tsx
@@ -77,7 +77,7 @@ const StoryGenerator: React.FC = () => {
         type: 'warning',
         message: 'Please configure your API key in settings first'
       });
-      setCurrentSection('settings');
+      setCurrentSection('api-settings');
       return;
     }
 
@@ -637,7 +637,7 @@ const StoryGenerator: React.FC = () => {
                 This enables access to various AI models for story generation.
               </p>
               <button
-                onClick={() => setCurrentSection('settings')}
+                onClick={() => setCurrentSection('api-settings')}
                 className="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors"
               >
                 Configure API Settings

--- a/src/components/UserOnboarding.tsx
+++ b/src/components/UserOnboarding.tsx
@@ -141,7 +141,7 @@ const UserOnboarding: React.FC<UserOnboardingProps> = ({ isOpen, onClose, onComp
       action: {
         label: 'Try Story Generation',
         onClick: () => {
-          setCurrentSection('story');
+          setCurrentSection('story-generator');
           addNotification({
             type: 'info',
             message: 'Fill out the story form and click "Generate Story" to see the magic!'


### PR DESCRIPTION
## Summary
- update `story` section references to `story-generator`
- rename `settings` section to `api-settings`
- build to confirm navigation

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684104373034832fa01d460548ab464f