### PR TITLE
Fix dashboard section IDs and add missing component renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,10 @@ import { useEffect } from 'react';
 import APISettings from './components/APISettings';
 import AuthModal from './components/AuthModal';
 import Dashboard from './components/Dashboard';
+import Projects from './components/Projects';
+import DrawingCanvas from './components/DrawingCanvas';
+import PDFExport from './components/PDFExport';
+import KDPCompliance from './components/KDPCompliance';
 import HelpCenter from './components/HelpCenter';
 import NotificationContainer from './components/NotificationContainer';
 import Sidebar from './components/Sidebar';
@@ -43,6 +47,10 @@ function App() {
             )}
             <div className="p-6 overflow-auto flex-grow">
               {currentSection === 'dashboard' && <Dashboard onOpenStorage={() => {}} />}
+              {currentSection === 'projects' && <Projects />}
+              {currentSection === 'canvas' && <DrawingCanvas />}
+              {currentSection === 'pdf' && <PDFExport />}
+              {currentSection === 'kdp' && <KDPCompliance />}
               {currentSection === 'api-settings' && <APISettings />}
               {currentSection === 'story-generator' && <StoryGenerator />}
               {currentSection === 'image-generator' && <ImageGenerator />}

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -55,7 +55,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onOpenStorage }) => {
       description: 'Create engaging stories with detailed image prompts for coloring pages',
       icon: BookOpen,
       color: 'from-blue-500 to-purple-600',
-      action: () => setCurrentSection('story')
+      action: () => setCurrentSection('story-generator')
     },
     {
       title: 'Digital Canvas',
@@ -90,7 +90,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onOpenStorage }) => {
       description: 'Configure OpenRouter API for story and image generation',
       icon: Settings,
       color: 'from-gray-500 to-gray-700',
-      action: () => setCurrentSection('settings')
+      action: () => setCurrentSection('api-settings')
     }
   ];
 
@@ -309,7 +309,7 @@ const Dashboard: React.FC<DashboardProps> = ({ onOpenStorage }) => {
                 Create New Project
               </button>
               <button
-                onClick={() => setCurrentSection('story')}
+                onClick={() => setCurrentSection('story-generator')}
                 className="bg-green-600 text-white px-6 py-3 rounded-lg font-semibold hover:bg-green-700 transition-colors duration-200"
               >
                 Generate AI Story


### PR DESCRIPTION
## Summary
- adjust Dashboard feature cards and Get Started buttons to use correct section IDs
- render projects, canvas, PDF export and KDP compliance sections in App
- import newly added components in App

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684104342a88832fa59816895b262611