### PR TITLE
Add navigation sections

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,21 @@
 import React from 'react';
 import { useAppStore } from '../store/useAppStore';
 import { Section } from '../types'; // Import Section type
-import { Home, Settings, BookOpen, Palette, UploadCloud, User, HelpCircle, ChevronLeft, ChevronRight, LogOut } from 'lucide-react';
+import {
+  Home,
+  Settings,
+  BookOpen,
+  Palette,
+  FileText,
+  FolderOpen,
+  CheckCircle,
+  UploadCloud,
+  User,
+  HelpCircle,
+  ChevronLeft,
+  ChevronRight,
+  LogOut,
+} from 'lucide-react';
 
 const Sidebar: React.FC = () => {
   const {
@@ -45,8 +59,12 @@ const Sidebar: React.FC = () => {
       <nav className="flex-grow p-4 space-y-2 overflow-y-auto">
         {[
           { id: 'dashboard' as Section, label: 'Dashboard', icon: Home },
+          { id: 'projects' as Section, label: 'Projects', icon: FolderOpen },
           { id: 'story-generator' as Section, label: 'Story Generator', icon: BookOpen },
           { id: 'image-generator' as Section, label: 'Image Generator', icon: Palette },
+          { id: 'canvas' as Section, label: 'Canvas', icon: Palette },
+          { id: 'pdf' as Section, label: 'PDF Export', icon: FileText },
+          { id: 'kdp' as Section, label: 'KDP Compliance', icon: CheckCircle },
         ].map((item) => (
           <button
             key={item.id}


### PR DESCRIPTION
## Summary
- expand lucide-react icon imports in Sidebar
- add Projects, Canvas, PDF Export, and KDP Compliance nav items

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6841061ca784832f8e9e79c20b745dc8

## Summary by Sourcery

Add new navigation sections to the Sidebar and import their associated icons

New Features:
- Add Projects, Canvas, PDF Export, and KDP Compliance nav items to the sidebar

Enhancements:
- Expand lucide-react imports to include FileText, FolderOpen, and CheckCircle icons