### PR TITLE
Fix notification wording

### DIFF
--- a/src/components/StoryGenerator.tsx
+++ b/src/components/StoryGenerator.tsx
@@ -75,7 +75,7 @@ const StoryGenerator: React.FC = () => {
     if (!apiSettings.apiKey) {
       addNotification({
         type: 'warning',
-        message: 'Please configure your API key in settings first'
+        message: 'Please configure your API key in API Settings first'
       });
       setCurrentSection('api-settings');
       return;


### PR DESCRIPTION
## Summary
- clarify instructions for setting up API key

## Testing
- `npm run lint` *(fails: ERR_MODULE_NOT_FOUND)*

------
https://chatgpt.com/codex/tasks/task_e_68410afcb1b4832f92dccc82e0396c55