### PR TITLE
Add README note on persistent storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ A comprehensive tool for creating professional-quality coloring books with AI-ge
 - **✅ KDP Compliance**: Comprehensive Amazon KDP requirements checker
 - **⚙️ Settings**: API configuration, project settings, and preferences
 - **🔔 Notifications**: Real-time feedback system with toast notifications
+- **💾 Persistent Storage**: Manage and back up all projects with IndexedDB and
+  local backups
 - **📱 Responsive**: Works perfectly on desktop, tablet, and mobile devices
 
 ### 🎯 AI Integration


### PR DESCRIPTION
## Summary
- document persistent storage feature in README

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68410acb5060832fb5c5ed5ef4da3856

## Summary by Sourcery

Documentation:
- Add a README entry for Persistent Storage with IndexedDB and local backups