### PR TITLE
Fix API key notice in StoryGenerator

### DIFF
--- a/src/components/StoryGenerator.tsx
+++ b/src/components/StoryGenerator.tsx
@@ -77,6 +77,7 @@ const StoryGenerator: React.FC = () => {
         type: 'warning',
         message: 'Please configure your API key in API Settings first'
       });
+      // Redirect the user to the settings page to enter their API key
       setCurrentSection('api-settings');
       return;
     }


### PR DESCRIPTION
## Summary
- clarify redirect comment when API key is missing

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*

------
https://chatgpt.com/codex/tasks/task_e_68410c65cb74832f822bb24db9ad0cb2