### PR TITLE
Enable real Stripe checkout in payment modal

### DIFF
--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -17,6 +17,7 @@ const plans = [
     name: 'Free',
     price: 0,
     period: 'forever',
+    priceId: null,
     icon: Star,
     color: 'from-gray-500 to-gray-600',
     features: {
@@ -39,6 +40,7 @@ const plans = [
     name: 'Pro',
     price: 19,
     period: 'month',
+    priceId: process.env.VITE_STRIPE_PRO_PRICE_ID || '',
     icon: Zap,
     color: 'from-blue-500 to-purple-600',
     popular: true,
@@ -62,6 +64,7 @@ const plans = [
     name: 'Enterprise',
     price: 99,
     period: 'month',
+    priceId: process.env.VITE_STRIPE_ENTERPRISE_PRICE_ID || '',
     icon: Crown,
     color: 'from-purple-600 to-pink-600',
     features: {
@@ -108,12 +111,12 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose }) => {
             status: 'active'
           }
         });
-        
+
         addNotification({
           type: 'success',
           message: 'Welcome to ColorBook Engine Free plan!'
         });
-        
+
         onClose();
       } catch (error) {
         addNotification({
@@ -127,32 +130,43 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose }) => {
     setIsProcessing(true);
 
     try {
-      // Simulate payment processing
-      await new Promise(resolve => setTimeout(resolve, 2000));
-      
-      // For demo purposes, simulate successful payment
-      const mockSubscription = {
-        tier: selectedPlan as 'free' | 'pro' | 'enterprise',
-        status: 'active' as const,
-        expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString() // 30 days from now
-      };
-      
-      await updateUser({
-        subscription: mockSubscription
+      const plan = plans.find(p => p.id === selectedPlan);
+      if (!plan?.priceId) {
+        throw new Error('Invalid plan configuration');
+      }
+
+      const token = localStorage.getItem('authToken');
+      const response = await fetch('/api/payments/create-checkout-session', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { 'Authorization': `Bearer ${token}` } : {})
+        },
+        body: JSON.stringify({
+          priceId: plan.priceId,
+          successUrl: `${window.location.origin}/subscription/success`,
+          cancelUrl: `${window.location.origin}/subscription`,
+          metadata: { planId: plan.id }
+        })
       });
-      
-      addNotification({
-        type: 'success',
-        message: `Successfully subscribed to ${selectedPlanData?.name} plan!`
-      });
-      
-      onClose();
+
+      if (!response.ok) {
+        throw new Error('Failed to create checkout session');
+      }
+
+      const data = await response.json();
+      const url = data.sessionUrl || data.url;
+      if (url) {
+        window.location.href = url;
+      } else {
+        throw new Error('Invalid session response');
+      }
     } catch (error) {
+      console.error('Checkout error:', error);
       addNotification({
         type: 'error',
-        message: 'Payment failed. Please try again.'
+        message: 'Failed to start checkout session'
       });
-    } finally {
       setIsProcessing(false);
     }
   };


### PR DESCRIPTION
## Summary
- wire up payment modal to real API endpoint
- redirect to Stripe checkout

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68410e271bb8832fb39a7f6ec549ca2d

## Summary by Sourcery

Enable real Stripe checkout in the payment modal by sourcing plan price IDs from env vars, calling the backend to create a checkout session, and redirecting users to Stripe with proper error handling.

New Features:
- Integrate real Stripe checkout by creating checkout sessions via the backend and redirecting users to Stripe.

Enhancements:
- Load subscription plan price IDs from environment variables.
- Replace mock payment simulation with an API call to /api/payments/create-checkout-session and redirect to the returned session URL.
- Implement error handling and user notifications for invalid configurations and checkout failures.