### PR TITLE
Hook up login/register to backend

### DIFF
--- a/src/components/AuthModal.tsx
+++ b/src/components/AuthModal.tsx
@@ -72,16 +72,16 @@ const AuthModal: React.FC<AuthModalProps> = ({ isOpen, onClose, initialMode = 'l
     
     try {
       if (mode === 'login') {
-        await login(formData.email);
-        addNotification({ 
-          type: 'success', 
-          message: 'Welcome back! Successfully logged in.' 
+        await login(formData.email, formData.password);
+        addNotification({
+          type: 'success',
+          message: 'Welcome back! Successfully logged in.'
         });
       } else {
-        await register(formData.email, formData.name!);
-        addNotification({ 
-          type: 'success', 
-          message: 'Account created successfully! Welcome to ColorBook Engine.' 
+        await register(formData.email, formData.name!, formData.password);
+        addNotification({
+          type: 'success',
+          message: 'Account created successfully! Welcome to ColorBook Engine.'
         });
       }
       


### PR DESCRIPTION
## Summary
- wire useAppStore authentication actions to backend API
- send password credentials from `AuthModal`

## Testing
- `npm run lint` *(fails: Cannot find package '@typescript-eslint/eslint-plugin')*
- `npm run build` *(fails: Cannot find type definition file for 'node')*

------
https://chatgpt.com/codex/tasks/task_e_68410e25c088832fbb954401857810da