### PR TITLE
Add real API testing docs and helper script

### DIFF
--- a/.env.test.example
+++ b/.env.test.example
@@ -1,0 +1,18 @@
+# Example API credentials for running end-to-end tests with real AI services
+# Copy this file to `.env.test` and fill in your actual keys.
+
+# ----- Story Generation -----
+# OpenRouter API key
+OPENROUTER_API_KEY=sk-or-your-openrouter-key
+
+# ----- Image Generation -----
+# OpenAI DALL-E API key (optional)
+OPENAI_API_KEY=sk-openai-your-key
+# Stability AI API key (optional)
+STABILITY_API_KEY=sk-stability-your-key
+# Replicate API token (optional)
+REPLICATE_API_TOKEN=r8-your-token
+
+# ----- Google Imagen / Vertex AI (optional) -----
+GOOGLE_CLOUD_PROJECT_ID=your-project-id
+GOOGLE_SERVICE_ACCOUNT_KEY={"type":"service_account"}

--- a/.gitignore
+++ b/.gitignore
@@ -108,4 +108,5 @@ backend/uploads/
 
 # API keys and secrets
 .env*
+!.env.test.example
 config/keys.js

--- a/README.md
+++ b/README.md
@@ -156,6 +156,14 @@ Update these values in `.env` or your production configuration to tune API rate
 limits for your deployment.
 - The backend relies on **rate-limiter-flexible** v7.1.1 for in-memory limiting.
 
+### Testing with Real AI Services
+To run the automated tests against the live image and story generation APIs:
+
+1. Copy `.env.test.example` to `.env.test` and add your API credentials.
+2. Execute `./scripts/load-test-env.sh` to load the keys and run the tests.
+
+See [REAL_API_TESTING.md](REAL_API_TESTING.md) for full details.
+
 ## License
 
 This project is licensed under the [MIT License](LICENSE).

--- a/REAL_API_TESTING.md
+++ b/REAL_API_TESTING.md
@@ -1,0 +1,33 @@
+# Real API Testing Setup
+
+This project supports running the automated test suite against the live image and story generation services. To do so, valid API credentials must be provided via environment variables.
+
+## 1. Create `.env.test`
+Copy the provided `.env.test.example` file to `.env.test` in the project root and fill in your API keys:
+
+```bash
+cp .env.test.example .env.test
+```
+
+Populate the file with your credentials:
+
+- `OPENROUTER_API_KEY` – required for story generation.
+- `OPENAI_API_KEY` – optional, used for DALL‑E image generation.
+- `STABILITY_API_KEY` – optional, used for Stable Diffusion generation.
+- `REPLICATE_API_TOKEN` – optional, used for Replicate models.
+- `GOOGLE_CLOUD_PROJECT_ID` and `GOOGLE_SERVICE_ACCOUNT_KEY` – optional, used for Google Imagen/Vertex AI.
+
+Any variables left blank will disable that provider during tests.
+
+## 2. Run Tests with Credentials
+Use the helper script to load the environment file and execute the backend tests:
+
+```bash
+./scripts/load-test-env.sh
+```
+
+The script sources `.env.test` if present and then runs `npm test` inside the `backend` directory. You can pass additional arguments to Jest after the script.
+
+## Notes
+- The `.env.test` file is ignored by git so your secrets remain local.
+- If no credentials are supplied, tests will run using the mocked services and skip live generation.

--- a/scripts/load-test-env.sh
+++ b/scripts/load-test-env.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Load API credentials for tests and run backend tests
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+ENV_FILE="$ROOT_DIR/.env.test"
+
+if [ -f "$ENV_FILE" ]; then
+  echo "Loading test credentials from $ENV_FILE"
+  set -o allexport
+  source "$ENV_FILE"
+  set +o allexport
+else
+  echo "No .env.test file found. Using existing environment variables."
+fi
+
+cd "$ROOT_DIR/backend" || exit 1
+npm test "$@"


### PR DESCRIPTION
## Summary
- show how to run tests with real AI API keys
- include sample `.env.test.example`
- add helper script `scripts/load-test-env.sh`
- mention new instructions in README

## Testing
- `./scripts/load-test-env.sh`

------
https://chatgpt.com/codex/tasks/task_e_68410e2080b8832fb41e3d87bdcddc55

## Summary by Sourcery

Enable testing against live AI services by adding documentation, example config, and a helper script to load API credentials and run backend tests.

Documentation:
- Add REAL_API_TESTING.md with detailed setup instructions for real API testing
- Update README to reference real AI services testing instructions

Tests:
- Add scripts/load-test-env.sh to load environment credentials and run backend tests
- Include .env.test.example as a template for API key configuration