### PR TITLE
Update auth actions

### DIFF
--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -214,13 +214,31 @@ export const useAppStore = create<AppState>()(
         try {
           set({ isInitializingAuth: true });
 
-          const response = await backendAPI.login({ email, password });
+          const res = await fetch('/api/auth/login', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password })
+          });
 
-          if (response.error || !response.data) {
-            throw new Error(response.message || 'Login failed');
+          const data = await res.json();
+
+          if (!res.ok) {
+            throw new Error(data.message || 'Login failed');
           }
 
-          const { user, tokens } = response.data;
+          const { user, tokens } = data;
+
+          // Persist tokens for backendAPI and components
+          if (tokens?.accessToken) {
+            localStorage.setItem('accessToken', tokens.accessToken);
+            localStorage.setItem('authToken', tokens.accessToken);
+            if (tokens.refreshToken) {
+              localStorage.setItem('refreshToken', tokens.refreshToken);
+            }
+            // Update backendAPI instance with fresh tokens
+            (backendAPI as any).accessToken = tokens.accessToken;
+            (backendAPI as any).refreshToken = tokens.refreshToken;
+          }
 
           set({
             user: {
@@ -250,17 +268,30 @@ export const useAppStore = create<AppState>()(
         try {
           set({ isInitializingAuth: true });
 
-          const response = await backendAPI.register({
-            email,
-            password,
-            username: name,
+          const res = await fetch('/api/auth/register', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ email, password, username: name })
           });
 
-          if (response.error || !response.data) {
-            throw new Error(response.message || 'Registration failed');
+          const data = await res.json();
+
+          if (!res.ok) {
+            throw new Error(data.message || 'Registration failed');
           }
 
-          const { user, tokens } = response.data;
+          const { user, tokens } = data;
+
+          // Persist tokens for backendAPI and components
+          if (tokens?.accessToken) {
+            localStorage.setItem('accessToken', tokens.accessToken);
+            localStorage.setItem('authToken', tokens.accessToken);
+            if (tokens.refreshToken) {
+              localStorage.setItem('refreshToken', tokens.refreshToken);
+            }
+            (backendAPI as any).accessToken = tokens.accessToken;
+            (backendAPI as any).refreshToken = tokens.refreshToken;
+          }
 
           set({
             user: {


### PR DESCRIPTION
## Summary
- send login and register requests directly to `/api/auth` endpoints
- store returned JWT in localStorage and update backend API client

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684112175bbc832f88d2ca8eb540b3b1

## Summary by Sourcery

Update authentication actions to use direct fetch calls to `/api/auth` endpoints, handle JSON responses, and persist JWT tokens

Enhancements:
- Replace backendAPI.login and .register with POST fetch requests to `/api/auth/login` and `/api/auth/register`
- Persist access and refresh tokens in localStorage for use across the app
- Update the backend API client instance with fresh tokens after login and registration